### PR TITLE
docs: add go-live plan v2

### DIFF
--- a/GO_LIVE_READINESS_v2.md
+++ b/GO_LIVE_READINESS_v2.md
@@ -33,6 +33,6 @@
 - **Caching** – Marker/Detector-Module im Prozess cachen; Cache-Bust via Change Stream.
 - **NLP-Aktivierung** – Spark-NLP oder produktives NLP-Backend einschalten; Token/Offsets zurückgeben für exaktes Highlighting.
 - **Scoring-Pfad** – Aggregat-Score („Resonanz“) berechnen und transportieren; Frontend-Gauge anbinden.
-- **Tests grün kriegen** – fehlende Pakete nachziehen (z. B. sqlalchemy), CI-Matrix bauen (unit/integration/load/security).
+- **Fix failing tests** – fehlende Pakete nachziehen (z. B. sqlalchemy), CI-Matrix bauen (unit/integration/load/security).
 - **Observability** – Prometheus-Metriken (Latenz, Fehlerquote, LLM-Quota), strukturierte Logs, Alerts.
 - **Deploy-Konfig** – Env-Variablen (LLM-Keys, DETECTOR_PATH, Mongo-URL) dokumentieren, Secrets trennen, Smoke-Test-Route.


### PR DESCRIPTION
## Summary
- document event/change-stream triggers and cache invalidation
- specify marker_resonance WebSocket event schema
- outline go-live checklist for backend readiness

## Testing
- `cd backend && pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `cd frontend && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68a38d802ee48322a27089c9e0687226